### PR TITLE
Update `settings.py` to support different environments

### DIFF
--- a/backend/cultidate/settings.py
+++ b/backend/cultidate/settings.py
@@ -11,10 +11,15 @@ https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
 import os
-import django_heroku
+
 import dj_database_url
+import django_heroku
 from dotenv import load_dotenv
+
 load_dotenv()
+
+DJANGO_ENV = os.getenv('DJANGO_ENV', 'development')
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -79,15 +84,15 @@ WSGI_APPLICATION = 'cultidate.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
-db_from_env = dj_database_url.config(conn_max_age=500, ssl_require=True)
-DATABASES['default'].update(db_from_env)
+if DJANGO_ENV == 'production':
+    db_from_env = dj_database_url.config(conn_max_age=500, ssl_require=True)
+    DATABASES['default'].update(db_from_env)
 
 
 # Password validation


### PR DESCRIPTION
As we talked, we can use SQLite for local development database, so I adjusted our settings.py file a little bit to support `development` and `production` environments. On Heroku, I've set `DJANGO_ENV` to `production`.